### PR TITLE
ci: modernize release.yml GitHub Actions versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Prepare Plugin Package
         run: |
@@ -32,7 +32,7 @@ jobs:
                     --exclude='.idea/' \
                     --exclude='.vs/' \
                     Plugins/AssetsBridge/ release/AssetsBridge/
-          
+
       - name: Create Source Zip
         run: |
           cd release
@@ -47,7 +47,7 @@ jobs:
           git push origin :refs/tags/source || true
 
       - name: Create Source Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: source
           name: "Latest Source"
@@ -87,7 +87,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get version from tag
         id: version
@@ -120,7 +120,7 @@ jobs:
           zip -r ../AssetsBridge-${{ steps.version.outputs.tag }}-UE${{ matrix.ue_version }}.zip AssetsBridge/
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: AssetsBridge-${{ steps.version.outputs.tag }}-UE${{ matrix.ue_version }}
           path: AssetsBridge-${{ steps.version.outputs.tag }}-UE${{ matrix.ue_version }}.zip
@@ -135,7 +135,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get version from tag
         id: version
@@ -144,7 +144,7 @@ jobs:
           echo "tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           pattern: AssetsBridge-*
@@ -167,7 +167,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.version.outputs.tag }}
           name: "AssetsBridge v${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
Modernizes the four outdated GitHub Actions in `.github/workflows/release.yml` (the only workflow in this repo). Versions resolved against each action's latest GitHub release as of 2026-06-03.

## The 4 bumps

| Action | Where | Old -> New | Tier | Breaking-change note |
|---|---|---|---|---|
| `actions/checkout` | source-release L23, version-release L90, create-release L138 | `@v4` -> `@v6` | low-risk | node24 runtime; behavior-compatible on hosted `ubuntu-latest`. Lowest risk of the set. |
| `actions/upload-artifact` | version-release L123 | `@v4` -> `@v7` | known-breaking | Already past the v3->v4 immutability break. Artifact names are unique per UE version (`AssetsBridge-<tag>-UE<ver>`), so the no-same-name-reupload rule is satisfied. A v4->v7 multi-major jump — verify before relying on it. |
| `actions/download-artifact` | create-release L147 | `@v4` -> `@v8` | known-breaking | Uses `pattern: AssetsBridge-*` + `merge-multiple: true` into `artifacts/`, then `files: artifacts/*.zip`. v4+ already downloads each artifact to its own subdir and merge-multiple flattens, so likely compatible — confirm the create-release glob still resolves after the v4->v8 jump. |
| `softprops/action-gh-release` | source-release prerelease L50, versioned `make_latest` L170 | `@v2` -> `@v3` | known-breaking, HIGHEST RISK | This is the actual release-creating step, used twice. v3 bumped the node runtime and adjusted input handling. Verify `files:` globs, `tag_name`, `prerelease`/`make_latest`, and body templating still behave before a real cut. |

## Why this is not auto-merged

`release.yml` is the ONLY workflow in this repo and it is tag-gated: the `source-release` job runs on push to `main`, and `version-release` + `create-release` run only on `push: tags: v*`. A branch/PR push never exercises the tag jobs, so **no `gh pr checks` run can validate these bumps** — this is a release-only repo and the bumps are unverifiable by branch CI.

The handler must never cut a tag to test a release, so the only authoritative validation is a real release on your own cadence. Validate-then-merge is yours: apply this branch, then cut a release (or run a scratch/fork pre-release tag across the 5.4/5.5/5.6/5.7 matrix) to confirm the per-UE zips still build, upload, download, and publish before merging.

Branched from `origin/main` @ 46d3c70 (v1.3.0 release commit).

Eventic-Task: 019e80b9-65f9-7003-8e4c-06592b7843e3